### PR TITLE
Add missing "Vehicle Distance Measure Filtered" id

### DIFF
--- a/gdo.guides/Secplus-GDO-Setup-Guide.md
+++ b/gdo.guides/Secplus-GDO-Setup-Guide.md
@@ -258,6 +258,7 @@ sensor:
 
 # Vehicle ToF Sensor - Required for the VL53L1X
 #   - platform: copy
+#     id: gdo_tof_distance_filtered      
 #     source_id: gdo_tof_distance
 #     name: Vehicle Distance Measure Filtered
 #     filters:


### PR DESCRIPTION
The copy of "Vehicle Distance Measure Filtered" is missing and id causing a compilation error when using the ToF sensor and i2c config.